### PR TITLE
bump to qutebrowser-2.0.1

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -1,6 +1,6 @@
 cask "qutebrowser" do
-  version "2.0.0"
-  sha256 "c6fb92d9c6f168a725522bdb980e5e2558982eb1e237e1cb23bc22db3998a274"
+  version "2.0.1"
+  sha256 "4ce1912de5fb9b25d64ce812d06354a54832b3edb7d7504b294c5e3b9e062bcf"
 
   url "https://github.com/qutebrowser/qutebrowser/releases/download/v#{version}/qutebrowser-#{version}.dmg",
       verified: "github.com/qutebrowser/qutebrowser/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

> The submission is for a stable version

Yes, https://github.com/qutebrowser/qutebrowser/releases/tag/v2.0.1

> `brew audit --cask {{cask_file}}` is error-free.

```
audit for qutebrowser: passed
```

> `brew style --fix {{cask_file}}` reports no offenses.

```
1 file inspected, no offenses detected
```